### PR TITLE
Update for linkedin-api-client 0.7 & use Guzzle 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "illuminate/http": "~5.1 || ~5.2",
         "illuminate/support": "~5.1 || ~5.2",
         "illuminate/database": "~5.1 || ~5.2",
-        "happyr/linkedin-api-client": "0.6.*"
+        "happyr/linkedin-api-client": "0.7.*",
+        "php-http/guzzle6-adapter": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0"

--- a/tests/LinkedinClassTest.php
+++ b/tests/LinkedinClassTest.php
@@ -29,9 +29,10 @@ class LinkedinClassTest extends PhpUnit
      */
     public function testConstructor()
     {
-        $this->assertEquals($this->linkedin->getAppId(), '123456789',
-            'Expect the App ID to be set.');
-        $this->assertEquals($this->linkedin->getAppSecret(), '987654321',
-            'Expect the API secret to be set.');
+        $this->assertEquals(
+            $this->linkedin->isAuthenticated(),
+            false,
+            'Expect the current user is authenticated.'
+        );
     }
 }


### PR DESCRIPTION
Update for
- happyr/linkedin-api-client 0.7
- use php-http/guzzle6-adapter to resolve Guzzle 6 depence #1
