### PR TITLE
Updated to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=7.0.0",
         "illuminate/contracts": "~5.0",
         "illuminate/http": "~5.0",
         "illuminate/support": "~5.0",
@@ -22,7 +22,7 @@
         "php-http/message": "^1.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
+        "phpunit/phpunit": "~6.0",
         "orchestra/testbench": "~3.4@dev"
     },
     "autoload": {


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0`.

Dropped support to `PHP 5.6` and `HHVM`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).